### PR TITLE
Add Pair component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 
 # Editor specifics
 .vscode/*
+.idea/*

--- a/src/Pair.js
+++ b/src/Pair.js
@@ -1,0 +1,40 @@
+// A component rendering a key,value pair
+class Pair {
+	/**
+	 * Creates a new Pair instance
+	 * @param {Component} key Key component
+	 * @param {Component} value Value component
+	 */
+	constructor(key, value) {
+		this._key = key;
+		this._value = value;
+	}
+
+	render(el) {
+		this._key.render(el);
+		this._value.render(el);
+	}
+
+	unrender() {
+		this._key.unrender();
+		this._value.unrender();
+	}
+
+	/**
+	 * Get the key component.
+	 * @returns {Component} the key component
+	 */
+	getKeyComponent() {
+		return this._key;
+	}
+
+	/**
+	 * Get the value component.
+	 * @returns {Component} the value component
+	 */
+	getValueComponent() {
+		return this._value;
+	}
+}
+
+export default Pair;

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import Checkbox from './Checkbox.js';
 import Elem from './Elem.js';
 import Html from './Html.js';
 import Input from './Input.js';
+import Pair from './Pair.js';
 import Radio, { generateName } from './Radio.js';
 import RootElem from './RootElem.js';
 import Select from './Select.js';
@@ -14,4 +15,4 @@ import Textarea from './Textarea.js';
 import Transition from './Transition.js';
 import Txt from './Txt.js';
 
-export { Button, Checkbox, Elem, Html, Input, Radio, RootElem, Select, Textarea, Transition, Txt, generateName };
+export { Button, Checkbox, Elem, Html, Input, Pair, Radio, RootElem, Select, Textarea, Transition, Txt, generateName };


### PR DESCRIPTION
The `Pair` is just a grouping of two `Elem` instances and provided as a
convenient way to return a component from a component factory that
contains both a key and a value component.